### PR TITLE
Set Statcounter location to United States

### DIFF
--- a/LegalNoticeFooterModule.php
+++ b/LegalNoticeFooterModule.php
@@ -172,7 +172,7 @@ class LegalNoticeFooterModule extends PrivacyPolicy
         'statcounter' => [
             'name' => 'Statcounter™',
             'url' => 'https://statcounter.com',
-            'country' => 'Ireland',
+            'country' => 'United States',
         ],
     ];
 


### PR DESCRIPTION
## Summary
- change the predefined Statcounter service location from Ireland to United States

## Verification
- `php -l LegalNoticeFooterModule.php`
- `git diff --check`