### PR TITLE
Collect privacy notices from compatible modules

### DIFF
--- a/LegalNoticeFooterModule.php
+++ b/LegalNoticeFooterModule.php
@@ -1195,7 +1195,7 @@ class LegalNoticeFooterModule extends PrivacyPolicy
             'trackingServices'          => $this->trackingServices($tree, $user),
             'thirdPartyServices'        => $this->thirdPartyServices(),
             'cookiesServices'           => [],
-            'externalTranscriptionProviders' => [],
+            'moduleSecurityMeasures'     => $this->moduleSecurityMeasures(),
             //'usercentricsLanguages' => self::USERCENTRICS_LANGUAGES,
             'https'                     => legalNoticeSupport::getHttps($request),
             'hostingDomain'             => LegalNoticeSupport::getHostName($request),
@@ -1249,13 +1249,9 @@ class LegalNoticeFooterModule extends PrivacyPolicy
             $services[] = self::OPENSTREETMAP_SERVICE;
         }
 
-        $services = [
-            ...$services,
-            ...$this->externalTranscriptionProviders(),
-        ];
-
         return array_map(fn (array $service): array => $this->withThirdCountryTransferFlag($service), [
             ...$services,
+            ...$this->moduleThirdPartyServices(),
             ...$this->additionalThirdPartyServices(),
         ]);
     }
@@ -1308,29 +1304,106 @@ class LegalNoticeFooterModule extends PrivacyPolicy
     }
 
     /**
-     * External transcription providers announced by hh_source_transcription, if installed.
+     * Privacy notices announced by other enabled modules.
      *
-     * @return list<array{name:string,url:string,country:string,data:list<string>,thirdCountryTransfer:bool}>
+     * The current lightweight module contract is intentionally method-based:
+     * modules may expose a public privacyNotices() method without importing a
+     * shared interface from this module.
+     *
+     * @return array{third_party_services:list<array<string,mixed>>,security_measures:list<string>}
      */
-    private function externalTranscriptionProviders(): array
+    private function modulePrivacyNotices(): array
     {
-        $sourceTranscription = '\Hartenthaler\Webtrees\Module\SourceTranscription\SourceTranscription';
+        $notices = [
+            'third_party_services' => [],
+            'security_measures' => [],
+        ];
 
-        if (!class_exists($sourceTranscription) || !method_exists($sourceTranscription, 'externalProviderPrivacyNotices')) {
-            return [];
+        foreach ($this->moduleService->all() as $module) {
+            if ($module === $this || !method_exists($module, 'privacyNotices')) {
+                continue;
+            }
+
+            try {
+                $moduleNotices = $module->privacyNotices();
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (!is_array($moduleNotices)) {
+                continue;
+            }
+
+            foreach ($moduleNotices['third_party_services'] ?? [] as $service) {
+                if (is_array($service)) {
+                    $normalized = $this->normalizedThirdPartyService($service);
+
+                    if ($normalized !== null) {
+                        $notices['third_party_services'][] = $normalized;
+                    }
+                }
+            }
+
+            foreach ($moduleNotices['security_measures'] ?? [] as $measure) {
+                $measure = trim((string) $measure);
+
+                if ($measure !== '') {
+                    $notices['security_measures'][] = $measure;
+                }
+            }
         }
 
-        try {
-            $providers = $sourceTranscription::externalProviderPrivacyNotices();
-        } catch (Throwable) {
-            return [];
+        return $notices;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function moduleThirdPartyServices(): array
+    {
+        return $this->modulePrivacyNotices()['third_party_services'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function moduleSecurityMeasures(): array
+    {
+        return $this->modulePrivacyNotices()['security_measures'];
+    }
+
+    /**
+     * @param array<string,mixed> $service
+     *
+     * @return array<string,mixed>|null
+     */
+    private function normalizedThirdPartyService(array $service): ?array
+    {
+        $name = trim((string) ($service['name'] ?? ''));
+        $url = trim((string) ($service['url'] ?? ''));
+
+        if ($name === '' || $url === '') {
+            return null;
         }
 
-        if (!is_array($providers)) {
-            return [];
+        $data = [];
+        foreach ($service['data'] ?? [] as $dataCategory) {
+            $dataCategory = trim((string) $dataCategory);
+
+            if ($dataCategory !== '') {
+                $data[] = $dataCategory;
+            }
         }
 
-        return array_map(fn (array $provider): array => $this->withThirdCountryTransferFlag($provider), $providers);
+        return [
+            'name' => $name,
+            'url' => $url,
+            'country' => trim((string) ($service['country'] ?? '')),
+            'privacy_url' => trim((string) ($service['privacy_url'] ?? '')),
+            'data' => $data,
+            'description' => trim((string) ($service['description'] ?? '')),
+            'group' => trim((string) ($service['group'] ?? '')),
+        ];
     }
 
     private function registeredUsersAreRelatives(): bool

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ The generated privacy policy can also mention [Google Charts](https://developers
 
 Additional third-party services can be configured by the administrator using service name, URL, and optional country of service provision. If the website is subject to EU data-protection law and a configured service is provided from outside the European Union, the generated privacy policy can include a third-country-transfer notice.
 
-The privacy-policy page can also include information from other installed modules. For example, if `hh_source_transcription` is installed, this module can show privacy information about external transcription providers such as Transkribus or Discourse.
+The privacy-policy page can also include information from other installed modules. Compatible modules can expose a public `privacyNotices(): array` method. The method may currently return `third_party_services` entries with `name`, `url`, optional `country`, `privacy_url`, `description`, `data`, and `group`, plus `security_measures` text entries. This is used, for example, by `hh_source_transcription` for external transcription providers such as Transkribus or Discourse.
 
 The wording for the webtrees core cookie behavior is being clarified separately; see issue [#48](https://github.com/hartenthaler/hh_legal_notice/issues/48).
 

--- a/resources/views/page/sections/security-measures.phtml
+++ b/resources/views/page/sections/security-measures.phtml
@@ -13,6 +13,14 @@ use Fisharebest\Webtrees\I18N;
         <?= I18N::translate('These measures include, in particular, securing the confidentiality, integrity, and availability of data, including by controlling access to the data.') ?>
     </p>
 
+    <?php if (count($moduleSecurityMeasures) > 0) : ?>
+        <ul>
+            <?php foreach ($moduleSecurityMeasures as $moduleSecurityMeasure) : ?>
+                <li><?= e($moduleSecurityMeasure) ?></li>
+            <?php endforeach ?>
+        </ul>
+    <?php endif ?>
+
     <?php if ($https) : ?>
         <h5><?= I18N::translate('SSL or TLS encryption') ?></h5>
 

--- a/resources/views/page/sections/third-party-services.phtml
+++ b/resources/views/page/sections/third-party-services.phtml
@@ -15,7 +15,7 @@ use Hartenthaler\Webtrees\Module\LegalNotice\Internationalization\MoreI18N;
         <?php endif ?>
     <?php endforeach ?>
 
-    <?php if (count($thirdPartyServices) > 0 || count($externalTranscriptionProviders) > 0 || count($nonLocalTrackingServices) > 0) : ?>
+    <?php if (count($thirdPartyServices) > 0 || count($nonLocalTrackingServices) > 0) : ?>
         <h3 class="hh-legal-notice-section"><?= e($chapter->getHeading()) ?></h3>
 
         <p>
@@ -93,7 +93,7 @@ use Hartenthaler\Webtrees\Module\LegalNotice\Internationalization\MoreI18N;
                 </ul>
             <?php endif ?>
 
-            <?php $otherThirdPartyServicesWithData = array_filter($thirdPartyServicesWithData, static fn (array $service): bool => in_array(($service['name'] ?? ''), ['Google Charts', 'Gravatar'], true)) ?>
+            <?php $otherThirdPartyServicesWithData = array_filter($thirdPartyServicesWithData, static fn (array $service): bool => in_array(($service['name'] ?? ''), ['Google Charts', 'Gravatar'], true) || (($service['description'] ?? '') !== '' && ($service['group'] ?? '') !== 'transcription')) ?>
             <?php if (count($otherThirdPartyServicesWithData) > 0) : ?>
                 <h5><?= I18N::translate('Additional third-party service details') ?></h5>
 
@@ -105,6 +105,8 @@ use Hartenthaler\Webtrees\Module\LegalNotice\Internationalization\MoreI18N;
                                 <?= I18N::translate('Google Charts may be loaded from Google servers when statistics charts are viewed.') ?>
                             <?php elseif (($service['name'] ?? '') === 'Gravatar') : ?>
                                 <?= I18N::translate('Gravatar may be loaded from Automattic servers when the responsible person image is displayed.') ?>
+                            <?php elseif (($service['description'] ?? '') !== '') : ?>
+                                <?= e($service['description']) ?>
                             <?php endif ?>
                             <?php if (count($service['data'] ?? []) > 0) : ?>
                                 <br>
@@ -132,7 +134,7 @@ use Hartenthaler\Webtrees\Module\LegalNotice\Internationalization\MoreI18N;
             <?php endif ?>
         <?php endif ?>
 
-        <?php $transcriptionProviders = array_filter($thirdPartyServices, static fn (array $service): bool => count($service['data'] ?? []) > 0 && !in_array(($service['name'] ?? ''), ['OpenStreetMap', 'Google Charts', 'Gravatar'], true)) ?>
+        <?php $transcriptionProviders = array_filter($thirdPartyServices, static fn (array $service): bool => ($service['group'] ?? '') === 'transcription') ?>
         <?php if (count($transcriptionProviders) > 0) : ?>
             <h5><?= I18N::translate('External transcription providers') ?></h5>
 


### PR DESCRIPTION
## Summary
- Add a lightweight `privacyNotices()` module contract for compatible custom modules.
- Collect third-party service entries and security-measure notes from enabled modules.
- Render module-provided service descriptions in the third-party services section and module-provided security notes in the security measures section.
- Document the supported return shape in the README.

## Verification
- `php -l LegalNoticeFooterModule.php`
- `php -l resources/views/page/sections/third-party-services.phtml`
- `php -l resources/views/page/sections/security-measures.phtml`
- `git diff --check`