### PR TITLE
Use is_callable for privacy notice providers

### DIFF
--- a/LegalNoticeFooterModule.php
+++ b/LegalNoticeFooterModule.php
@@ -76,6 +76,7 @@ use function date;
 use function filter_var;
 use function floor;
 use function is_array;
+use function is_callable;
 use function in_array;
 use function max;
 use function method_exists;
@@ -1653,7 +1654,7 @@ class LegalNoticeFooterModule extends PrivacyPolicy
         ];
 
         foreach ($this->moduleService->all() as $module) {
-            if ($module === $this || !method_exists($module, 'privacyNotices')) {
+            if ($module === $this || !is_callable([$module, 'privacyNotices'])) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- detect privacy-notice providers with `is_callable()` instead of `method_exists()`
- skip inaccessible or otherwise non-callable `privacyNotices()` methods before invocation

## Rationale

The lightweight privacy-notice contract is optional and method-based. Checking
callability more accurately represents that contract than checking only whether
a method with the expected name exists.

This is a small compatibility improvement related to #68 and #124.

## Validation

- `php -l LegalNoticeFooterModule.php`
- `git diff --check`
