### PR TITLE
Hide empty legal regulations heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This release prepares updated documentation, screenshots, and translations and r
 * Active map providers and map links can be listed as third-party services.
 * The privacy policy can include further webtrees privacy information as a separate section.
 * German copyright wording now distinguishes general AI/text-and-data-mining wording from references that only apply under German law.
+* Optional main chapters with no enabled sections are no longer shown as empty headings.
 * The README screenshots and Dutch translation have been updated.
 
 ## ✨ What's still open

--- a/resources/views/page.phtml
+++ b/resources/views/page.phtml
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Fisharebest\Webtrees\View;
+use Hartenthaler\Webtrees\Module\LegalNotice\LegalNoticeSupport;
 use Illuminate\Support\Collection;
 
 /**
@@ -106,6 +107,10 @@ use Illuminate\Support\Collection;
         <?php endif ?>
 
         <?php if ($chapter->getKey() === 'LegalRegulations' && !$showLegalRegulations) : ?>
+            <?php continue; ?>
+        <?php endif ?>
+
+        <?php if (!LegalNoticeSupport::hasEnabledChildChapter($chapters, $chapter)) : ?>
             <?php continue; ?>
         <?php endif ?>
 

--- a/src/LegalNoticeSupport.php
+++ b/src/LegalNoticeSupport.php
@@ -334,6 +334,20 @@ class LegalNoticeSupport
     }
 
     /**
+     * @param array<int|string,Chapter> $chapters
+     */
+    public static function hasEnabledChildChapter(array $chapters, Chapter $parentChapter): bool
+    {
+        foreach ($chapters as $chapter) {
+            if ($chapter->getLink() === $parentChapter->getId() && $chapter->getEnabled()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return array<string,string>
      */
     public static function sectionViewByChapterKey(): array


### PR DESCRIPTION
## Summary

- skip optional main chapters when none of their direct child sections are enabled
- prevents the **Legal Regulations** heading from rendering by itself when all legal-regulation sections are disabled
- document the behavior in the README change notes

Fixes #130

## Validation

- `php -l src/LegalNoticeSupport.php`
- `php -l resources/views/page.phtml`
- `Get-ChildItem -Recurse -Include *.php,*.phtml | ForEach-Object { php -l $_.FullName }`
- `git diff --check`